### PR TITLE
Alternative approach to updating

### DIFF
--- a/src/Models/Concerns/StoreAsFlatfile.php
+++ b/src/Models/Concerns/StoreAsFlatfile.php
@@ -145,8 +145,8 @@ trait StoreAsFlatfile
 
         $driver = Flatfile::driver(static::getFlatfileDriver());
 
+        $afterInsert = collect();
         foreach (static::getFlatfileResolvers() as $handle => $directory) {
-            $afterInsert = collect();
             $driver->all($this, $handle, $directory)
                 ->chunk(500)
                 ->each(function (LazyCollection $chunk) use ($afterInsert) {
@@ -168,14 +168,14 @@ trait StoreAsFlatfile
                         dd($e);
                     }
                 });
+        }
 
-            foreach ($afterInsert as $row) {
-                if (! $values = $row['updateAfterInsert']()) {
-                    continue;
-                }
-
-                static::newQuery()->where('id', $row['id'])->update($values);
+        foreach ($afterInsert as $row) {
+            if (! $values = $row['updateAfterInsert']()) {
+                continue;
             }
+
+            static::newQuery()->where('id', $row['id'])->update($values);
         }
     }
 


### PR DESCRIPTION
This PR reduces the amount of looping required by building a new afterInsert collection as it loops. 
On my test site this consistently reduces the `flatfile:cache` time by around 30%.