### PR TITLE
Ensure db path is set up and torn down completely

### DIFF
--- a/src/Commands/ClearCache.php
+++ b/src/Commands/ClearCache.php
@@ -30,12 +30,17 @@ class ClearCache extends Command
     public function handle()
     {
         $path = Flatfile::getDatabasePath();
+        $paths = [
+            $path,
+            $path . '-shm',
+            $path . '-wal',
+        ];
 
-        if (! file_exists($path)) {
-            return;
+        foreach ($paths as $path) {
+            if (file_exists($path) && !unlink($path)) {
+                $this->components->error("Failed to delete file: $path");
+            }
         }
-
-        unlink($path);
 
         $this->components->info('Its gone...');
     }

--- a/src/Models/Concerns/StoreAsFlatfile.php
+++ b/src/Models/Concerns/StoreAsFlatfile.php
@@ -5,6 +5,7 @@ namespace Thoughtco\StatamicStacheSqlite\Models\Concerns;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\LazyCollection;
 use Illuminate\Support\Str;
 use ReflectionClass;
@@ -38,9 +39,15 @@ trait StoreAsFlatfile
 
         $model = (new static);
 
+        $dbPath = Flatfile::getDatabasePath();
+        if (! file_exists($dbPath)) {
+            File::ensureDirectoryExists(dirname($dbPath));
+            touch($dbPath);
+        }
+
         if (
             Flatfile::isTesting() ||
-            filemtime($modelFile) > filemtime(Flatfile::getDatabasePath()) ||
+            filemtime($modelFile) > filemtime($dbPath) ||
             $driver->shouldRestoreCache($model, static::getFlatfileResolvers()) ||
             ! static::resolveConnection()->getSchemaBuilder()->hasTable($model->getTable())
         ) {

--- a/src/Models/Concerns/StoreAsFlatfile.php
+++ b/src/Models/Concerns/StoreAsFlatfile.php
@@ -5,7 +5,6 @@ namespace Thoughtco\StatamicStacheSqlite\Models\Concerns;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Filesystem\Filesystem;
-use Illuminate\Support\Facades\File;
 use Illuminate\Support\LazyCollection;
 use Illuminate\Support\Str;
 use ReflectionClass;
@@ -39,15 +38,9 @@ trait StoreAsFlatfile
 
         $model = (new static);
 
-        $dbPath = Flatfile::getDatabasePath();
-        if (! file_exists($dbPath)) {
-            File::ensureDirectoryExists(dirname($dbPath));
-            touch($dbPath);
-        }
-
         if (
             Flatfile::isTesting() ||
-            filemtime($modelFile) > filemtime($dbPath) ||
+            filemtime($modelFile) > filemtime(Flatfile::getDatabasePath()) ||
             $driver->shouldRestoreCache($model, static::getFlatfileResolvers()) ||
             ! static::resolveConnection()->getSchemaBuilder()->hasTable($model->getTable())
         ) {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -21,6 +21,7 @@ class ServiceProvider extends AddonServiceProvider
             $database = Flatfile::getDatabasePath();
 
             if (! $fs->exists($database) && $database !== ':memory:') {
+                $fs->ensureDirectoryExists(dirname($database));
                 $fs->put($database, '');
             }
 


### PR DESCRIPTION
With WAL mode enabled, need to clean up the -shm and -wal files when clearing the db.
Also, the db path is not guaranteed to be created when it is used in the bootStoreAsFlatfile() method.
Just added a few checks for both of these.