### PR TITLE
Throw exception during -ing hooks to prevent desync between flat file

### DIFF
--- a/src/Models/Concerns/StoreAsFlatfile.php
+++ b/src/Models/Concerns/StoreAsFlatfile.php
@@ -56,7 +56,10 @@ trait StoreAsFlatfile
             // and default values from the SQLite cache.
             // $model->refresh();
 
-            Flatfile::driver(static::getFlatfileDriver())->save($model);
+            if (!Flatfile::driver(static::getFlatfileDriver())->save($model)) {
+                return false;
+            }
+
             event(new FlatfileCreated($model));
         });
 
@@ -65,7 +68,10 @@ trait StoreAsFlatfile
                 return;
             }
 
-            Flatfile::driver(static::getFlatfileDriver())->save($model);
+            if (!Flatfile::driver(static::getFlatfileDriver())->save($model)) {
+                return false;
+            }
+
             event(new FlatfileUpdated($model));
         });
 
@@ -74,7 +80,10 @@ trait StoreAsFlatfile
                 return;
             }
 
-            Flatfile::driver(static::getFlatfileDriver())->delete($model);
+            if (!Flatfile::driver(static::getFlatfileDriver())->delete($model)) {
+                return false;
+            }
+
             event(new FlatfileDeleted($model));
         });
     }
@@ -302,26 +311,24 @@ trait StoreAsFlatfile
         return 'yaml';
     }
 
-    public function deleteFlatfile(Driver $driver)
+    public function deleteFlatfile(Driver $driver): bool
     {
-        unlink($driver->filepath($this->getFlatfileRootDirectory(), $this));
-
-        return true;
+        return unlink($driver->filepath($this->getFlatfileRootDirectory(), $this));
     }
 
-    public function writeFlatfile(Driver $driver)
+    public function writeFlatfile(Driver $driver): bool
     {
         $path = $driver->filepath($this->getFlatfileRootDirectory(), $this);
 
         if ($this->file_path_read_from && ($path != $this->file_path_read_from)) {
-            unlink($this->file_path_read_from);
+            if (!unlink($this->file_path_read_from)) {
+                return false;
+            }
         }
 
         $fs = new Filesystem;
         $fs->ensureDirectoryExists(dirname($path));
 
-        if (file_put_contents($path, $this->fileContents()) === false) {
-            throw new \RuntimeException("Failed to write to {$path}");
-        }
+        return file_put_contents($path, $this->fileContents()) !== false;
     }
 }

--- a/src/Models/Concerns/StoreAsFlatfile.php
+++ b/src/Models/Concerns/StoreAsFlatfile.php
@@ -56,7 +56,7 @@ trait StoreAsFlatfile
             // and default values from the SQLite cache.
             // $model->refresh();
 
-            if (!Flatfile::driver(static::getFlatfileDriver())->save($model)) {
+            if (! Flatfile::driver(static::getFlatfileDriver())->save($model)) {
                 return false;
             }
 
@@ -68,7 +68,7 @@ trait StoreAsFlatfile
                 return;
             }
 
-            if (!Flatfile::driver(static::getFlatfileDriver())->save($model)) {
+            if (! Flatfile::driver(static::getFlatfileDriver())->save($model)) {
                 return false;
             }
 
@@ -80,7 +80,7 @@ trait StoreAsFlatfile
                 return;
             }
 
-            if (!Flatfile::driver(static::getFlatfileDriver())->delete($model)) {
+            if (! Flatfile::driver(static::getFlatfileDriver())->delete($model)) {
                 return false;
             }
 
@@ -321,7 +321,7 @@ trait StoreAsFlatfile
         $path = $driver->filepath($this->getFlatfileRootDirectory(), $this);
 
         if ($this->file_path_read_from && ($path != $this->file_path_read_from)) {
-            if (!unlink($this->file_path_read_from)) {
+            if (! unlink($this->file_path_read_from)) {
                 return false;
             }
         }

--- a/src/Models/Concerns/StoreAsFlatfile.php
+++ b/src/Models/Concerns/StoreAsFlatfile.php
@@ -47,7 +47,7 @@ trait StoreAsFlatfile
             $model->migrate();
         }
 
-        static::created(function (Model $model) {
+        static::creating(function (Model $model) {
             if ($model->callTraitMethod('shouldCreate', $model) === false) {
                 return;
             }
@@ -56,35 +56,26 @@ trait StoreAsFlatfile
             // and default values from the SQLite cache.
             // $model->refresh();
 
-            $status = Flatfile::driver(static::getFlatfileDriver())->save($model);
-
+            Flatfile::driver(static::getFlatfileDriver())->save($model);
             event(new FlatfileCreated($model));
-
-            return $status;
         });
 
-        static::updated(function (Model $model) {
+        static::updating(function (Model $model) {
             if ($model->callTraitMethod('shouldUpdate', $model) === false) {
                 return;
             }
 
-            $status = Flatfile::driver(static::getFlatfileDriver())->save($model);
-
+            Flatfile::driver(static::getFlatfileDriver())->save($model);
             event(new FlatfileUpdated($model));
-
-            return $status;
         });
 
-        static::deleted(function (Model $model) {
+        static::deleting(function (Model $model) {
             if ($model->callTraitMethod('shouldDelete', $model) === false) {
                 return;
             }
 
-            $status = Flatfile::driver(static::getFlatfileDriver())->delete($model);
-
+            Flatfile::driver(static::getFlatfileDriver())->delete($model);
             event(new FlatfileDeleted($model));
-
-            return $status;
         });
     }
 
@@ -329,8 +320,8 @@ trait StoreAsFlatfile
         $fs = new Filesystem;
         $fs->ensureDirectoryExists(dirname($path));
 
-        file_put_contents($path, $this->fileContents());
-
-        return true;
+        if (file_put_contents($path, $this->fileContents()) === false) {
+            throw new \RuntimeException("Failed to write to {$path}");
+        }
     }
 }


### PR DESCRIPTION
Changed the hooks from post variant to the in progress variant. (ie. created => creating)
Then added an exception to be thrown when the file_put_contents fails.

The combination of both of these prevents the db cache from getting out of sync with the flat files when the saving of the flat files fails.  In other words, the db won't be written to unless the flat file is properly written.